### PR TITLE
Remove form elements' focus outline

### DIFF
--- a/ress.css
+++ b/ress.css
@@ -205,6 +205,14 @@ textarea {
   border-style: none;
 }
 
+a:focus,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline-width: 0;
+}
+
 /* Style select like a standard input */
 select {
   -moz-appearance: none; /* Firefox 36+ */


### PR DESCRIPTION
This removes outlines around focused form elements, which is not
consistently applied across all browsers. Most notably, Chrome recently
rolled out an [update which adds large outlines around focused form
elements](https://stackoverflow.com/questions/61992025/google-chrome-showing-black-border-on-focus-state-for-button-user-agent-styles).

See also https://blog.chromium.org/2020/03/updates-to-form-controls-and-focus.html