### PR TITLE
Avoid `cursor: default` when `aria-disabled="false"`

### DIFF
--- a/ress.css
+++ b/ress.css
@@ -274,6 +274,6 @@ progress {
 }
 
 /* Specify the unstyled cursor of disabled, not-editable, or otherwise inoperable elements */
-[aria-disabled] {
+[aria-disabled="true"] {
   cursor: default;
 }


### PR DESCRIPTION
## Before fix

- `<a href="" aria-disabled="false">` => default cursor
- `<a href="" aria-disabled="true">` => default cursor

## After fix

- `<a href="" aria-disabled="false">` => pointer cursor
- `<a href="" aria-disabled="true">` => default cursor