### PR TITLE
Change out rawgit links to jsDelivr

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,1 @@
 custom: https://www.buymeacoffee.com/filipe/
-github: gregoryhammond
-ko_fi: gregoryh

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
-custom: https://www.buymeacoffee.com/filipe
+custom: https://www.buymeacoffee.com/filipe/
+github: gregoryhammond
+ko_fi: gregoryh

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ Inherit from [Normalize](https://github.com/necolas/normalize.css#browser-suppor
 https://unpkg.com/ress/dist/ress.min.css
 ```
 
-[**RawGit**](https://rawgit.com)
+[**jsDevlivr**](https://www.jsdelivr.com/)
 
 ```sh
 # Production
-https://cdn.rawgit.com/filipelinhares/ress/master/dist/ress.min.css
+https://cdn.jsdelivr.net/npm/ress@4.0.0/dist/ress.min.css
 
 # Development
-https://rawgit.com/filipelinhares/ress/master/dist/ress.min.css
+https://cdn.jsdelivr.net/gh/filipelinhares/ress@latest/dist/ress.min.css
 ```
 
 ## License


### PR DESCRIPTION
[Rawgit has been in the sunset phase for a couple of years now (since October 2018) and the creator has encouraged people to use alternatives.](https://web.archive.org/web/20210306083601/https://rawgit.com/)

I have replaced the rawgit links with JSDelivr links.